### PR TITLE
update year in profile readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -9,4 +9,4 @@ At Edgeless Systems, our mission is to make confidential computing accessible an
 * We have built easy-to-use, open-source tools that get you started in no time, check them out below.</li>
 * Check out our [whitepaper](https://content.edgeless.systems/hubfs/Confidential%20Computing%20Whitepaper.pdf) or visit our friends at the [Confidential Computing Consortium](https://confidentialcomputing.io) to find out more about all things confidential computing.
 
-<sub>[2022, Bochum, Germany](https://goo.gl/maps/VF9qjVtjzE8KT9jz6)</sub>
+<sub>[2024, Bochum, Germany](https://goo.gl/maps/VF9qjVtjzE8KT9jz6)</sub>


### PR DESCRIPTION
We could also just omit it, if we forget to update it.
Note that I implicitly assumed that this is similar to a copyright year on web pages and not like the date e.g., a blog post is written.